### PR TITLE
fe/refactor/modal

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,6 @@
 import {
   RouterProvider,
   createBrowserRouter,
-  useNavigate,
 } from 'react-router-dom';
 import './App.css';
 import LandingPage from 'pages/LandingPage';
@@ -66,6 +65,8 @@ function App() {
       ? clearAndNavigateToLanding
       : clearErrorMessage;
 
+  const { btns } = modalProps.error;
+
   return (
     <div className="App">
       <QueryClientProvider client={queryClient}>
@@ -74,14 +75,8 @@ function App() {
         <Modal
           isOpen={!!errorMessage}
           message={errorMessage}
-          messageFontSize={modalProps.error.messageFontSize}
-          btns={[
-            {
-              label: modalProps.error.btns[0].label,
-              onClick: handleClickModalAction,
-              type: modalProps.error.btns[0].type,
-            },
-          ]}
+          btns={btns}
+          buttonActions={[handleClickModalAction]}
         />
         <ReactQueryDevtools />
       </QueryClientProvider>

--- a/frontend/src/components/common/Modal/ErrorMessage.tsx
+++ b/frontend/src/components/common/Modal/ErrorMessage.tsx
@@ -1,0 +1,5 @@
+import 'styles/components/common/Modal/modal.scss';
+
+export const ErrorMessage = ({ errorMessage }: { errorMessage: string }) => {
+  return <div className="error-message">{errorMessage}</div>;
+};

--- a/frontend/src/components/common/Modal/Modal.tsx
+++ b/frontend/src/components/common/Modal/Modal.tsx
@@ -1,34 +1,29 @@
 import ReactDOM from 'react-dom';
 import ModalButton from 'components/common/Button/ModalButton';
 import 'styles/components/common/Modal/modal.scss';
-import NicknameInput from 'components/user/NicknameInput';
 import OverLay from 'components/common/Modal/OverLay';
-import { ButtonType, MessageFontSize, SetState } from 'types/common';
+import { ButtonType, MessageFontSize } from 'types/common';
+import { ReactNode } from 'react';
+import NicknameInput from 'components/user/NicknameInput';
+import { ErrorMessage } from './ErrorMessage';
+import { ModalImage } from './ModalImage';
 
 interface ModalProps {
   isOpen: boolean;
-  imageSrc?: string;
   message: string;
   messageFontSize?: MessageFontSize;
-  hasNicknameInput?: boolean;
-  nickname?: string;
-  setNickname?: SetState<string>;
-  errorMessage?: string;
-  setErrorMessage? : SetState<string>;
-  btns: { label: string; onClick: () => void; type: ButtonType }[];
+  btns: { label: string; type: ButtonType }[];
+  buttonActions: (() => void)[];
+  children?: ReactNode;
 }
 
 const Modal = ({
   isOpen,
-  imageSrc,
   message,
-  messageFontSize,
-  hasNicknameInput = false,
-  nickname,
-  setNickname,
-  errorMessage,
-  setErrorMessage,
+  messageFontSize = 'font-md',
   btns,
+  buttonActions,
+  children,
 }: ModalProps) => {
   if (!isOpen) return null;
 
@@ -36,24 +31,16 @@ const Modal = ({
     <div className="modal">
       <OverLay />
       <div className="container" onClick={(e) => e.stopPropagation()}>
-        {imageSrc && (
-          <img className="image" src={imageSrc} alt="Modal Visual" />
-        )}
         <div className={`message ${messageFontSize}`}>{message}</div>
-        {hasNicknameInput && nickname != undefined && setNickname && setErrorMessage && (
-          <div className="nickname-input">
-            <NicknameInput text="한글, 영어 2~6자" nickname={nickname} setNickname={setNickname} setErrorMessage={setErrorMessage}/>
-            <div className="error-message">{errorMessage}</div>
-          </div>
-        )}
+        {children}
         <div className="buttons">
           {btns.map((btn, index) => (
             <ModalButton
               key={index}
               label={btn.label}
-              onClick={btn.onClick}
+              onClick={buttonActions[index]}
               type={btn.type}
-            ></ModalButton>
+            />
           ))}
         </div>
       </div>
@@ -63,3 +50,7 @@ const Modal = ({
 };
 
 export default Modal;
+
+Modal.NicknameInput = NicknameInput;
+Modal.ErrorMessage = ErrorMessage;
+Modal.Image = ModalImage;

--- a/frontend/src/components/common/Modal/ModalImage.tsx
+++ b/frontend/src/components/common/Modal/ModalImage.tsx
@@ -1,0 +1,6 @@
+import 'styles/components/common/Modal/modal.scss';
+
+export const ModalImage = ({ imageSrc }: { imageSrc: string }) => {
+  return <img className="modal-image" src={imageSrc} alt="Modal Visual" />;
+};
+

--- a/frontend/src/constants/modal.ts
+++ b/frontend/src/constants/modal.ts
@@ -2,11 +2,11 @@ import { ButtonType, MessageFontSize } from 'types/common';
 
 interface ModalProps {
   message: string;
-  messageFontSize: MessageFontSize;
+  messageFontSize?: MessageFontSize;
   btns: { label: string; type: ButtonType }[];
 }
 
-type ModalKeys = 'logoutConfirm' | 'createNickname' | 'error';
+type ModalKeys = 'logoutConfirm' | 'createNickname' | 'gameResult' | 'error';
 
 type ModalPropsType = {
   [K in ModalKeys]: ModalProps;
@@ -14,8 +14,7 @@ type ModalPropsType = {
 
 export const modalProps: ModalPropsType = {
   logoutConfirm: {
-    message: '정말 로그아웃 하시겠습니까?',
-    messageFontSize: 'font-md',
+    message: '로그아웃 하시겠습니까?',
     btns: [
       { label: '확인', type: 'primary' },
       { label: '취소', type: 'secondary' },
@@ -23,13 +22,18 @@ export const modalProps: ModalPropsType = {
   },
   createNickname: {
     message: '닉네임을 입력해주세요.',
-    messageFontSize: 'font-md',
     btns: [{ label: '생성', type: 'primary' }],
+  },
+  gameResult: {
+    message: '',
+    messageFontSize: 'font-xl',
+    btns: [
+      { label: '재대결', type: 'primary' },
+      { label: '나가기', type: 'secondary' },
+    ],
   },
   error: {
     message: '',
-    messageFontSize: 'font-md',
     btns: [{ label: '확인', type: 'primary' }],
   },
 };
-

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -13,7 +13,7 @@ import { useLogout } from 'hooks/user/useLogout';
 const GuidePage = () => {
   const [selectedOption, setSelectedOption] = useState<GuideOption>('rule');
   const { isModalOpen, openModal, closeModal } = useModal();
-  const { message, messageFontSize, btns } = modalProps.logoutConfirm;
+  const { message, btns } = modalProps.logoutConfirm;
 
   const guideImage = selectedOption === 'rule' ? pond : farmer;
 
@@ -35,19 +35,8 @@ const GuidePage = () => {
       <Modal
         isOpen={isModalOpen}
         message={message}
-        messageFontSize={messageFontSize}
-        btns={[
-          {
-            label: btns[0].label,
-            onClick: executeKakaoLogout,
-            type: btns[0].type,
-          },
-          {
-            label: btns[1].label,
-            onClick: closeModal,
-            type: btns[1].type,
-          },
-        ]}
+        btns={btns}
+        buttonActions={[executeKakaoLogout, closeModal]}
       />
     </div>
   );

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -15,7 +15,7 @@ const LandingPage = () => {
   const [kakaoAccessToken, setKakaoAccessToken] = useState('');
   const [nicknameErrorMessage, setNicknameErrorMessage] = useState('');
   const [nickname, setNickname] = useState('');
-  const { message, messageFontSize, btns } = modalProps.createNickname;
+  const { message, btns } = modalProps.createNickname;
 
   // 1. 카카오 버튼 처음 눌렀을 때
   const code = new URL(window.location.href).searchParams.get('code');
@@ -47,20 +47,17 @@ const LandingPage = () => {
       <Modal
         isOpen={isModalOpen}
         message={message}
-        messageFontSize={messageFontSize}
-        hasNicknameInput={true}
-        nickname={nickname}
-        setNickname={setNickname}
-        btns={[
-          {
-            label: btns[0].label,
-            onClick: validateAndCreateUser,
-            type: btns[0].type,
-          },
-        ]}
-        errorMessage={nicknameErrorMessage}
-        setErrorMessage={setNicknameErrorMessage}
-      />
+        btns={btns}
+        buttonActions={[validateAndCreateUser]}
+      >
+        <Modal.NicknameInput
+          text="한글, 영어 2~6자"
+          nickname={nickname}
+          setNickname={setNickname}
+          setErrorMessage={setNicknameErrorMessage}
+        />
+        <Modal.ErrorMessage errorMessage={nicknameErrorMessage} />
+      </Modal>
     </div>
   );
 };

--- a/frontend/src/pages/PlayPage.tsx
+++ b/frontend/src/pages/PlayPage.tsx
@@ -6,6 +6,7 @@ import UserPlayBox from 'components/play/UserPlayBox';
 import CharacterList from 'components/play/CharacterList';
 import Board from 'components/play/Board';
 import Count from 'components/play/Count';
+import { modalProps } from 'constants/modal';
 
 const PlayPage = () => {
   //// [Modal 사용예시]
@@ -26,6 +27,8 @@ const PlayPage = () => {
   const handleStartCountEnd = () => {
     setStartCountVisible(false);
   };
+
+  const { messageFontSize, btns } = modalProps.gameResult;
 
   interface GameInfo {
     option: {
@@ -74,14 +77,13 @@ const PlayPage = () => {
 
       <Modal
         isOpen={isModalOpen}
-        imageSrc={eggwin}
-        message="아리 승!"
-        messageFontSize="font-xl"
-        btns={[
-          { label: '재대결', onClick: rematch, type: 'primary' },
-          { label: '나가기', onClick: closeModal, type: 'secondary' },
-        ]}
-      />
+        message="아리 승!" // 추후 동적으로 입력할 값
+        messageFontSize={messageFontSize}
+        btns={btns}
+        buttonActions={[rematch, closeModal]}
+      >
+        <Modal.Image imageSrc={eggwin} />
+      </Modal>
     </div>
   );
 };

--- a/frontend/src/styles/components/common/Modal/modal.scss
+++ b/frontend/src/styles/components/common/Modal/modal.scss
@@ -12,6 +12,7 @@
   z-index: 1000;
 
   .container {
+    @include flex-center;
     background: white;
     border: 5px solid $color-blue4;
     padding: 40px;
@@ -22,28 +23,13 @@
     max-width: 90%;
     min-height: 200px;
     max-height: 80%;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
     flex-direction: column;
 
-    .image {
-      position: absolute;
-      top: -50px;
-      left: 50%;
-      transform: translateX(-50%);
-      width: 80px;
-      height: 80px;
-      object-fit: cover;
-    }
-
     .message {
-      font-size: 35px;
-      text-align: center;
       line-height: 1;
-      margin-bottom: 20px;
+      margin-bottom: 15px;
       white-space: pre-wrap;
-      
+
       &.font-xl {
         font-size: $font-xl;
       }
@@ -53,19 +39,28 @@
       }
     }
 
-    .nickname-input {
-      margin-bottom: 20px;
-
-      .error-message {
-        color: $color-red4;
-        font-size: $font-xs;
-        margin: 5px 0 0 10px;
-      }
-    }
-
     .buttons {
       display: flex;
+      margin-top: 15px;
       gap: 25px;
     }
   }
+}
+
+.modal-image {
+  position: absolute;
+  top: -50px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 80px;
+  height: 80px;
+  object-fit: cover;
+}
+
+.error-message {
+  color: $color-red4;
+  font-size: $font-xs;
+  height: 12px;
+  padding-left: 5px;
+  width: 100%;
 }

--- a/frontend/src/styles/components/user/nickname-input.scss
+++ b/frontend/src/styles/components/user/nickname-input.scss
@@ -4,6 +4,7 @@ input {
   width: 100%;
   padding: 10px;
   font-size: $font-sm;
+  margin: 5px 0px;
   border: 1px solid #bfbbbb;
   border-radius: 5px;
   outline: none;


### PR DESCRIPTION
이슈 #19 에 관한 내용입니다.

[기존 문제]
1. Modal 컴포넌트에 모든 props를 할당하여 JSX에 많은 조건 렌더링이 들어감
2. 다양한 기능을 하는 모달이므로 유연성 필요

[해결 방법]
- Compound component 패턴을 적용
- 기본적으로 message(제목, 내용), btns은 Modal에서 필요하다 판단해 컴포넌트 안에 놔뒀고, 그 외 요소들은 개별 컴포넌트로 만들었습니다.
- 개별 컴포넌트마다 scss파일을 만들까하다가 modal에 귀속된다고 판단한 ModalImage(게임결과 모달의 구리와 아리), ErrorMessage 컴포넌트는 modal.scss 파일에 작성했습니다. 
  (scss파일이 너무 많아짐을 방지하고, 연관된 요소들을 한 파일에서 찾기 쉽게 하기 위해)
- 게임 결과 모달을 제외한 모든 모달에서 messageFontSize가 'font-md'여서 이를 기본값으로 하고 optional로 바꿨습니다. 
  (Modal을 사용하는 컴포넌트에서 prop을 하나라도 줄이기 위해)

[추가 개선사항]
![image](https://github.com/user-attachments/assets/c431df48-0315-49f3-a847-47dd893a407e)
Modal의 btns prop에 할당할 때 위와 같이 Modal을 사용하는 컴포넌트에서 btns의 index와 속성에 접근하는 불편함이 있었습니다. Modal을 사용하는 컴포넌트에서는 btns의 요소와 관심사를 분리하기 위해 buttonActions 속성을 추가하였고, 아래와 같이 변경했습니다.
![image2](https://github.com/user-attachments/assets/dd35d47b-0875-4843-8f6d-08908bc55574)