### PR TITLE
fe/feature/search-friend

### DIFF
--- a/frontend/src/api/axiosInstance.ts
+++ b/frontend/src/api/axiosInstance.ts
@@ -63,9 +63,7 @@ export const setAxiosInterceptorResponse = (
                   ) {
                     return true;
                   } else {
-                    setErrorMessage(
-                      COMMON_MESSAGES.RE_LOGIN
-                    );
+                    setErrorMessage(COMMON_MESSAGES.RE_LOGIN);
                     return false;
                   }
                 } finally {
@@ -85,9 +83,7 @@ export const setAxiosInterceptorResponse = (
               setErrorMessage(COMMON_MESSAGES.RE_LOGIN);
               break;
           }
-        } else if (err.code === 'ERR_NETWORK') {
-          setErrorMessage(ERROR_MESSAGES.COMMON.ERR_NETWORK);
-        } else {
+        } else if (!(err.code === 'ERR_NETWORK')) {
           setErrorMessage(ERROR_MESSAGES.COMMON.OTHER);
         }
       } else if (err instanceof Error) {

--- a/frontend/src/api/friendApi.ts
+++ b/frontend/src/api/friendApi.ts
@@ -1,0 +1,16 @@
+import { SearchFriendParams, SearchFriendResponse } from 'types/friend';
+import instance from './axiosInstance';
+import { API_ENDPOINTS } from 'constants/apiEndpoints';
+
+const searchFriend = async ({
+  nickname,
+}: SearchFriendParams): Promise<SearchFriendResponse> => {
+  const { data } = await instance.get(API_ENDPOINTS.SEARCH_FRIEND, {
+    params: {
+      nickname,
+    },
+  });
+  return data;
+};
+
+export { searchFriend };

--- a/frontend/src/api/queryClient.ts
+++ b/frontend/src/api/queryClient.ts
@@ -1,5 +1,15 @@
-import { QueryClient } from '@tanstack/react-query';
+import { MutationCache, QueryClient } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { ERROR_MESSAGES } from 'constants/errorMessages';
+import { useErrorStore } from 'stores/errorStore';
 
-export const queryClient = new QueryClient(
-  // defaultOptions 추가 예정
-)
+export const queryClient = new QueryClient({
+  mutationCache: new MutationCache({
+    onError: (err) => {
+      const { setErrorMessage } = useErrorStore.getState();
+      if (err instanceof AxiosError && err.code === 'ERR_NETWORK') {
+        setErrorMessage(ERROR_MESSAGES.COMMON.ERR_NETWORK);
+      }
+    },
+  }),
+});

--- a/frontend/src/components/common/Button/MiniButton.tsx
+++ b/frontend/src/components/common/Button/MiniButton.tsx
@@ -1,45 +1,32 @@
 import 'styles/components/common/Button/mini-button.scss';
 
 interface MiniButtonProps {
-  miniButtonOption: 'search' | 'add' | 'game' | 'accept' | 'reject';
+  type: 'search' | 'add' | 'game' | 'accept' | 'reject' | 'friend' | 'pending';
+  isLoading?: boolean;
+  onClick?: () => void;
 }
 
-const MiniButton = ({miniButtonOption}: MiniButtonProps) => {
-  
-  const handleClickSearchNickname = () => {
-    
-  }
+const MINI_BUTTON_CONTENTS = {
+  search: { text: '검색' },
+  add: { text: '친구 추가' },
+  game: { text: '대결 신청' },
+  accept: { text: '수락' },
+  reject: { text: '거절' },
+  pending: { text: '친추 취소' },
+  friend: { text: '이미 친구' },
+};
 
-  const handleClickAddFriend = () => {
-    
-  }
-
-  const handleClickRequestGame = () => {
-    
-  }
-
-  const handleClickAcceptFriend = () => {
-    
-  }
-
-  const handleClickRejectFriend = () => {
-    
-  }
-
-  const miniButtonOptions = {
-    search: { text: '검색', onClick: handleClickSearchNickname},
-    add: { text: '친구추가', onClick: handleClickAddFriend},
-    game: { text: '대결신청', onClick: handleClickRequestGame},
-    accept: { text: '수락', onClick: handleClickAcceptFriend},
-    reject: { text: '거절', onClick: handleClickRejectFriend},
-  }
-  const { onClick, text } = miniButtonOptions[miniButtonOption];
+const MiniButton = ({ type, onClick, isLoading }: MiniButtonProps) => {
+  const { text } = MINI_BUTTON_CONTENTS[type];
 
   return (
-    <div className={`mini-button ${miniButtonOption}`} onClick={onClick}>
+    <button
+      className={`mini-button ${type} ${isLoading ? 'disabled' : undefined}`}
+      onClick={onClick}
+    >
       {text}
-    </div>
-  )
-}
+    </button>
+  );
+};
 
-export default MiniButton
+export default MiniButton;

--- a/frontend/src/components/common/LoadingSpinner.tsx
+++ b/frontend/src/components/common/LoadingSpinner.tsx
@@ -5,12 +5,13 @@ import { MUTATION_KEYS } from 'constants/reactQueryKeys';
 import 'styles/components/common/loading-spinner.scss';
 
 const LoadingSpinner = () => {
-  const isFetching = useIsFetching();
+  // const isFetching = useIsFetching({ queryKey: [''] });
   const isLoginMutating = useIsMutating({
     mutationKey: [MUTATION_KEYS.login],
   });
-  const isLoading = !!(isFetching || isLoginMutating);
-  
+  // const isLoading = !!(isFetching || isLoginMutating);
+  const isLoading = !!isLoginMutating;
+
   return (
     <div className={`loading-spinner ${isLoading ? undefined : 'disabled'}`}>
       <OverLay />

--- a/frontend/src/components/user/BalloonTitle.tsx
+++ b/frontend/src/components/user/BalloonTitle.tsx
@@ -5,11 +5,7 @@ interface BalloonTitleProps {
 }
 
 const BalloonTitle = ({ title }: BalloonTitleProps) => {
-  return (
-    <div className="balloon-title">
-      <label>{title}</label>
-    </div>
-  );
+  return <h2 className="balloon-title">{title}</h2>;
 };
 
 export default BalloonTitle;

--- a/frontend/src/components/user/FriendListSection.tsx
+++ b/frontend/src/components/user/FriendListSection.tsx
@@ -4,22 +4,21 @@ import UserInfo from 'components/user/UserInfo';
 import MiniButton from 'components/common/Button/MiniButton';
 import UserState from 'components/user/UserState';
 import { UserInfoInterface } from 'types/user';
+import { FriendStatus } from 'types/friend';
+
+interface Friend {
+  userInfo: UserInfoInterface;
+  status: FriendStatus;
+}
 
 const FriendListSection = () => {
-  type userStateType = 'online' | 'offline' | 'playing';
-
-  interface User {
-    userInfo: UserInfoInterface;
-    state: userStateType;
-  }
-
-  const users: User[] = [
+  const users: Friend[] = [
     {
       userInfo: { nickname: '은지여섯글자', wins: 10, losses: 3 },
-      state: 'online',
+      status: 'online',
     },
-    { userInfo: { nickname: '현수', wins: 5, losses: 1 }, state: 'playing' },
-    { userInfo: { nickname: '에찌얌', wins: 4, losses: 1 }, state: 'offline' },
+    { userInfo: { nickname: '현수', wins: 5, losses: 1 }, status: 'playing' },
+    { userInfo: { nickname: '에찌얌', wins: 4, losses: 1 }, status: 'offline' },
   ];
 
   return (
@@ -33,10 +32,10 @@ const FriendListSection = () => {
                 userInfoOption="list"
                 userInfo={user.userInfo}
               />
-              {user.state === 'online' ? (
-                <MiniButton miniButtonOption="game" />
+              {user.status === 'online' ? (
+                <MiniButton type="game" />
               ) : (
-                <UserState state={user.state} />
+                <UserState state={user.status} />
               )}
             </div>
           );

--- a/frontend/src/components/user/FriendRequestSection.tsx
+++ b/frontend/src/components/user/FriendRequestSection.tsx
@@ -9,8 +9,8 @@ const FriendRequestSection = () => {
       <div className='request-box'>
         <span className='nickname'>은지여섯글자</span>
         <div className='button-box'>
-          <MiniButton miniButtonOption='accept'/>
-          <MiniButton miniButtonOption='reject'/>
+          <MiniButton type='accept'/>
+          <MiniButton type='reject'/>
         </div>
       </div>
     </div>

--- a/frontend/src/components/user/FriendSearchSection.tsx
+++ b/frontend/src/components/user/FriendSearchSection.tsx
@@ -30,6 +30,7 @@ const FriendSearchSection = () => {
           nickname={nickname}
           setNickname={setNickname}
           setErrorMessage={setNicknameErrorMessage}
+          onEnter={validateAndSearchFriend}
         />
         <MiniButton
           type="search"

--- a/frontend/src/components/user/FriendSearchSection.tsx
+++ b/frontend/src/components/user/FriendSearchSection.tsx
@@ -4,22 +4,49 @@ import NicknameInput from 'components/user/NicknameInput';
 import BalloonTitle from 'components/user/BalloonTitle';
 import UserInfo from 'components/user/UserInfo';
 import { useState } from 'react';
+import { ErrorMessage } from 'components/common/Modal/ErrorMessage';
+import { SearchFriendResponse } from 'types/friend';
+import { useSearchFriend } from 'hooks/friend/useSearchFriend';
 
 const FriendSearchSection = () => {
-  const userInfo = {nickname: '은지여섯글자', wins: 10, losses: 3};
   const [nickname, setNickname] = useState('');
-  const [errorMessage, setErrorMessage] = useState('');
+  const [nicknameErrorMessage, setNicknameErrorMessage] = useState('');
+
+  const { userInfo, searchFriendLoading, validateAndSearchFriend } =
+    useSearchFriend(nickname, setNicknameErrorMessage);
+
+  const getMiniButtonType = (userInfo: SearchFriendResponse) => {
+    if (userInfo.isFriend) return 'friend';
+    if (userInfo.isSent) return 'pending';
+    return 'add';
+  };
 
   return (
     <div className="friend-search-section">
       <BalloonTitle title="친구 검색" />
       <div className="friend-search-box">
-        <NicknameInput text="닉네임을 입력해주세요." nickname={nickname} setNickname={setNickname} setErrorMessage={setErrorMessage}/>
-        <MiniButton miniButtonOption="search" />
+        <NicknameInput
+          text="닉네임을 입력해주세요."
+          nickname={nickname}
+          setNickname={setNickname}
+          setErrorMessage={setNicknameErrorMessage}
+        />
+        <MiniButton
+          type="search"
+          onClick={validateAndSearchFriend}
+          isLoading={searchFriendLoading}
+        />
       </div>
-      <div className='result-box'>
-        <UserInfo userInfoOption='search' userInfo={userInfo}/>
-        <MiniButton miniButtonOption='add'/>
+      <div className="result-box">
+        {userInfo && (
+          <>
+            <UserInfo userInfoOption="search" userInfo={userInfo} />
+            <MiniButton type={getMiniButtonType(userInfo)} />
+          </>
+        )}
+        {nicknameErrorMessage && (
+          <ErrorMessage errorMessage={nicknameErrorMessage} />
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/user/NicknameInput.tsx
+++ b/frontend/src/components/user/NicknameInput.tsx
@@ -1,3 +1,4 @@
+import { KeyboardEventHandler } from 'react';
 import 'styles/components/user/nickname-input.scss';
 import { ChangeEvent, SetState } from 'types/common';
 
@@ -8,10 +9,11 @@ interface NicknameInputProps {
   text: string;
   nickname: string;
   setNickname: SetState<string>;
-  setErrorMessage: SetState<string>
+  setErrorMessage: SetState<string>;
+  onEnter: () => void;
 }
 
-const NicknameInput = ({ text, nickname, setNickname, setErrorMessage }: NicknameInputProps) => {
+const NicknameInput = ({ text, nickname, setNickname, setErrorMessage, onEnter }: NicknameInputProps) => {
   const handleChangeNickname = (e: ChangeEvent) => {
     setErrorMessage('');
     if (e.target.value.length > NICKNAME_MAX_LENGTH) {
@@ -21,6 +23,10 @@ const NicknameInput = ({ text, nickname, setNickname, setErrorMessage }: Nicknam
     }
   }
 
+  const executeOnEnter: KeyboardEventHandler<HTMLInputElement> = (e) => {
+    if (e.key === 'Enter') onEnter();
+  }
+
   return (
     <input
       className='nickname-input'
@@ -28,6 +34,7 @@ const NicknameInput = ({ text, nickname, setNickname, setErrorMessage }: Nicknam
       placeholder={text}
       value={nickname}
       onChange={(e) => handleChangeNickname(e)}
+      onKeyDown={executeOnEnter}
       pattern="^[가-힣a-zA-Z]{2,6}$"
       minLength={NICKNAME_MIN_LENGTH}
       maxLength={NICKNAME_MAX_LENGTH}

--- a/frontend/src/components/user/UserInfo.tsx
+++ b/frontend/src/components/user/UserInfo.tsx
@@ -7,15 +7,15 @@ interface UserInfoProps {
   userInfo: UserInfoInterface;
 }
 
-const UserInfo = ({userInfoOption, userInfo}: UserInfoProps) => {
-  const {nickname, wins, losses} = userInfo;
-  let color = userInfoOption === 'search' ? 'main-green' : 'main-yellow';
+const UserInfo = ({ userInfoOption, userInfo }: UserInfoProps) => {
+  const { nickname, wins, losses } = userInfo;
+  const color = userInfoOption === 'search' ? 'main-green' : 'main-yellow';
   return (
-    <div className='user-info'>
+    <div className="user-info">
       <span className={`nickname ${userInfoOption}`}>{nickname}</span>
-      <WinLoseBox wins={wins} losses={losses} color={color} size='font-md'/>
+      <WinLoseBox wins={wins} losses={losses} color={color} size="font-md" />
     </div>
-  )
-}
+  );
+};
 
-export default UserInfo
+export default UserInfo;

--- a/frontend/src/constants/errorMessages.ts
+++ b/frontend/src/constants/errorMessages.ts
@@ -1,7 +1,7 @@
-type ErrorMessageKeys =
+export type ErrorMessageKeys =
   | 'KAKAO_LOGIN'
   | 'KAKAO_LOGOUT'
-  | 'CREATE_USER'
+  | 'CREATE_NICKNAME'
   | 'SEARCH_FRIEND'
   | 'GET_FRIEND'
   | 'APPLY_FRIEND'
@@ -11,18 +11,18 @@ type ErrorMessageKeys =
   | 'GET_RANK'
   | 'COMMON';
 
-// type ErrorMessages = {
-//   [K in ErrorMessageKeys]: { [key: string]: string };
-// };
+type ErrorMessages = {
+  [K in ErrorMessageKeys]: { [key: string]: string };
+};
 
-interface ErrorMessages {
-  [key: string]: { [key: string]: string};
-}
+// interface ErrorMessages {
+//   [key: string]: { [key: string]: string};
+// }
 
 export const COMMON_MESSAGES = {
   RE_LOGIN: '다시 로그인 해주세요.',
   RETRY: '잠시 후 다시 시도해주세요.',
-}
+};
 
 // key: 서버에서 응답받은 errorType
 // value: 클라이언트에 보여줄 에러 문구
@@ -46,9 +46,16 @@ export const ERROR_MESSAGES: ErrorMessages = {
     INVALID_NICKNAME: '한글, 영어 2~6자',
     NOT_FOUND_USER: COMMON_MESSAGES.RE_LOGIN,
     DUPLICATED_NICKNAME: '이미 사용중인 닉네임입니다.',
-    ALREADY_EXISTS_NICKNAME: '이미 닉네임이 있습니다.'
+    ALREADY_EXISTS_NICKNAME: '이미 닉네임이 있습니다.',
   },
-  SEARCH_FRIEND: {},
+  SEARCH_FRIEND: {
+    FAILED_SEARCH_USER: COMMON_MESSAGES.RETRY,
+    INVALID_USERID: COMMON_MESSAGES.RE_LOGIN,
+    MISSING_NICKNAME: '닉네임을 입력해주세요.',
+    UNKNOWN_USER: '존재하지 않는 유저입니다.',
+    INVALID_NICKNAME: '한글, 영어 2~6자',
+    CANNOT_SEARCH_SELF: '본인은 검색할 수 없습니다.',
+  },
   GET_FRIEND: {},
   APPLY_FRIEND: {},
   GET_FRIEND_RECEIPTS: {},
@@ -58,6 +65,6 @@ export const ERROR_MESSAGES: ErrorMessages = {
   COMMON: {
     ERR_NETWORK: '서버 연결이 불안정합니다.\n잠시 후 다시 시도해주세요.',
     MISSING_JWT_ACCESS_TOKEN: COMMON_MESSAGES.RE_LOGIN,
-    OTHER: '알 수 없는 에러가 발생했습니다.\n잠시 후 다시 시도해주세요.',
+    OTHER: '에러가 발생했습니다.\n잠시 후 다시 시도해주세요.',
   },
 };

--- a/frontend/src/hooks/friend/useSearchFriend.ts
+++ b/frontend/src/hooks/friend/useSearchFriend.ts
@@ -1,0 +1,96 @@
+import { useQuery } from '@tanstack/react-query';
+import { searchFriend } from 'api/friendApi';
+import { AxiosError } from 'axios';
+import { COMMON_MESSAGES, ERROR_MESSAGES } from 'constants/errorMessages';
+import { QUERY_KEYS } from 'constants/reactQueryKeys';
+import { useEffect, useState } from 'react';
+import { useErrorStore } from 'stores/errorStore';
+import { SetState } from 'types/common';
+import { errorHandle } from 'utils/error';
+import { validateNickname } from 'utils/validate';
+
+const MAX_RETRIES = 3;
+
+export const useSearchFriend = (
+  nickname: string,
+  setNicknameErrorMessage: SetState<string>
+) => {
+  const { setErrorMessage } = useErrorStore();
+  const [searchedNickname, setSearchedNickname] = useState('');
+
+  const validateAndSearchFriend = () => {
+    if (!nickname) {
+      setNicknameErrorMessage(ERROR_MESSAGES.SEARCH_FRIEND.MISSING_NICKNAME);
+      return;
+    }
+
+    const isValidNickname = validateNickname(nickname);
+
+    if (!isValidNickname) {
+      setNicknameErrorMessage(ERROR_MESSAGES.SEARCH_FRIEND.INVALID_NICKNAME);
+      return;
+    }
+
+    setSearchedNickname(nickname);
+  };
+
+  const {
+    data: userInfo,
+    isLoading: searchFriendLoading,
+    isError: isSearchFriendError,
+    error: searchFriendError,
+  } = useQuery({
+    queryKey: [QUERY_KEYS.friends, searchedNickname],
+    queryFn: () => searchFriend({ nickname: searchedNickname }),
+    enabled: !!searchedNickname,
+    staleTime: 1000 * 60 * 30,
+    retry: (failureCount, err) => {
+      const canRetry = failureCount < MAX_RETRIES;
+
+      // 네트워크 오류, 서버 오류인 경우 재시도
+      if (err instanceof AxiosError) {
+        if (
+          err.code === 'ERR_NETWORK' ||
+          (err.response?.status && err.response?.status >= 500)
+        )
+          return canRetry;
+      }
+
+      // 그 외는 재시도 안함
+      return false;
+    },
+  });
+
+  useEffect(
+    function clearUserInfoUI() {
+      setSearchedNickname('');
+    },
+    [nickname]
+  );
+
+  useEffect(
+    function setSearchFriendErrorMessage() {
+      if (!isSearchFriendError || !(searchFriendError instanceof AxiosError)) {
+        return;
+      }
+      const errorType = searchFriendError.response?.data.errorType;
+
+      if (errorType === 'INVALID_USERID') {
+        setErrorMessage(COMMON_MESSAGES.RE_LOGIN);
+      } else {
+        errorHandle(
+          searchFriendError,
+          setNicknameErrorMessage,
+          'SEARCH_FRIEND'
+        );
+      }
+    },
+    [isSearchFriendError, searchFriendError]
+  );
+
+  return {
+    userInfo,
+    validateAndSearchFriend,
+    searchFriendLoading,
+  };
+};

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -57,6 +57,7 @@ const LandingPage = () => {
           nickname={nickname}
           setNickname={setNickname}
           setErrorMessage={setNicknameErrorMessage}
+          onEnter={validateAndCreateNickname}
         />
         <Modal.ErrorMessage errorMessage={nicknameErrorMessage} />
       </Modal>

--- a/frontend/src/styles/abstracts/_mixins.scss
+++ b/frontend/src/styles/abstracts/_mixins.scss
@@ -29,3 +29,10 @@
   gap: 10px;
   padding: 5px 0px;
 }
+
+@mixin disabled {
+  pointer-events: none;
+  color: #929292;
+  border: none;
+  background-color: #d9d9d9;
+}

--- a/frontend/src/styles/components/common/Button/mini-button.scss
+++ b/frontend/src/styles/components/common/Button/mini-button.scss
@@ -26,10 +26,24 @@
   &.accept {
     background-color: $color-blue3;
   }
-  
+
   &.reject {
     background-color: $color-blue2;
     color: $color-blue4;
     border: 1px solid $color-blue3;
+  }
+
+  &.pending {
+    color: #929292;
+    border: none;
+    background-color: #d9d9d9;
+  }
+
+  &.friend {
+    @include disabled;
+  }
+
+  &.disabled {
+    @include disabled;
   }
 }

--- a/frontend/src/styles/components/common/Button/modal-button.scss
+++ b/frontend/src/styles/components/common/Button/modal-button.scss
@@ -30,10 +30,6 @@
   }
 
   &.disabled {
-    pointer-events: none;
-    // cursor: not-allowed;
-    color: #929292;
-    border: none;
-    background-color: #D9D9D9;
+    @include disabled;
   }
 }

--- a/frontend/src/styles/components/common/Modal/modal.scss
+++ b/frontend/src/styles/components/common/Modal/modal.scss
@@ -63,4 +63,5 @@
   height: 12px;
   padding-left: 5px;
   width: 100%;
+  text-align: left;
 }

--- a/frontend/src/styles/components/user/balloon-title.scss
+++ b/frontend/src/styles/components/user/balloon-title.scss
@@ -1,11 +1,8 @@
 @import 'styles/abstracts/variables';
 
 .balloon-title {
-  display: flex;
-  justify-content: flex-start;
+  text-align: left;
+  font-weight: normal;
   margin-bottom: 10px;
-  label {
-    color: black;
-    font-size: $font-lg;
-  }
+  font-size: $font-lg;
 }

--- a/frontend/src/types/friend.ts
+++ b/frontend/src/types/friend.ts
@@ -1,0 +1,13 @@
+export interface SearchFriendParams {
+  nickname: string;
+}
+
+export interface SearchFriendResponse {
+  nickname: string;
+  wins: number;
+  losses: number;
+  isSent: boolean;
+  isFriend: boolean;
+}
+
+export type FriendStatus = 'online' | 'offline' | 'playing';

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -16,7 +16,6 @@ export interface KakaoLoginParams {
   code: string;
 }
 
-
 export interface CreateNicknameParams {
   userId: string;
   nickname: string;

--- a/frontend/src/utils/error.ts
+++ b/frontend/src/utils/error.ts
@@ -1,11 +1,11 @@
 import { AxiosError } from 'axios';
-import { ERROR_MESSAGES } from 'constants/errorMessages';
+import { ERROR_MESSAGES, ErrorMessageKeys } from 'constants/errorMessages';
 import { SetState } from 'types/common';
 
 export const errorHandle = (
   e: unknown,
   setErrorMessage: (errorMessage: string) => void | SetState<string>,
-  errorKey: string
+  errorKey: ErrorMessageKeys
 ) => {
   if (e instanceof AxiosError && e.response?.data.errorType) {
     // axiosInstance에서 처리한 에러를 중복 처리하지 않기 위해


### PR DESCRIPTION
1. 친구 검색 api 관련 프론트 코드 작성했습니다.
   (영상에는 에러 문구 색깔이 매번 다르게 나오는 것 같은데, 실제로 돌려보면 모두 빨간색입니다.)
![친구 검색 테스트](https://github.com/user-attachments/assets/8a4a0da3-431f-466b-a680-fbf20bfd160a)

2. 친구 검색에서 staleTime을 무한으로 주려다가(친구 추가, 친구 요청 취소 시 invalidate 할 거기 때문에), 해당 친구가 게임을 진행해 승패가 변한 경우를 추적해야 하기 때문에 30분으로 할당했습니다.

3. 리액트 쿼리는 useQuery를 사용할 때 요청 실패 시 기본적으로 3회 재시도를 하는데, 사용자 입력이 잘못됐을 경우는 재시도할 필요가 없다고 판단하여 네트워크 오류 및 서버 오류인 경우만 재시도하도록 했습니다. (횟수는 리액트 쿼리의 기본값이 3회를 따랐습니다.)

4. FriendSearchSection에서 3개의 api 연동(친구 검색, 친구 신청, 친추 취소하기)을 하기 때문에 해당 로직들을 컴포넌트에서 분리하기 위해  
   useFriendSearch 훅을 만들었습니다. (훅의 이름은 api이름이 아닌 컴포넌트명을 참조했습니다.)

5. isFriend, isSent에 따라 MiniButton에 type이 달라지는데, jsx 내에 분기 로직이 들어가면 복잡해져 getMiniButtonType 함수를 만들었습니다.
![image](https://github.com/user-attachments/assets/075ab919-e659-4005-87e8-fef4e21104fe)
![image](https://github.com/user-attachments/assets/d6951550-8433-49f1-bd4b-7c1e0d8b1698)

6. 기존에 axiosInstance에서 네트워크 오류를 전역적으로 처리했는데, query와 mutation을 구분하기 위해 queryClient에 기본값을 추가했습니다.

[추가]
* 웹 UX 향상을 위해 엔터 이벤트를 추가했습니다.