### PR TITLE
fe/feature/get-ranks

### DIFF
--- a/frontend/src/api/rankApi.ts
+++ b/frontend/src/api/rankApi.ts
@@ -1,0 +1,10 @@
+import { GetRankListResponse } from 'types/rank';
+import instance from './axiosInstance';
+import { API_ENDPOINTS } from 'constants/apiEndpoints';
+
+const getRankList = async (): Promise<GetRankListResponse> => {
+  const { data } = await instance.get(API_ENDPOINTS.GET_RANKS);
+  return data;
+};
+
+export { getRankList };

--- a/frontend/src/components/rank/UserRankItem.tsx
+++ b/frontend/src/components/rank/UserRankItem.tsx
@@ -15,11 +15,16 @@ interface UserRankItemProps {
   isMyRankSection: boolean;
 }
 
-const UserRankItem = ({ rank, userInfo, myNickname, isMyRankSection }: UserRankItemProps) => {
+const UserRankItem = ({
+  rank,
+  userInfo,
+  myNickname,
+  isMyRankSection,
+}: UserRankItemProps) => {
   const { nickname, wins, losses } = userInfo;
-  
+
   let color = isMyRankSection ? 'white' : 'rank-yellow';
-  let isTopRank = rank <= 3;
+  let isTopRank = rank !== null && rank <= 3;
 
   return (
     <div className={`user-rank-item ${isMyRankSection && 'my-rank'}`}>
@@ -31,8 +36,8 @@ const UserRankItem = ({ rank, userInfo, myNickname, isMyRankSection }: UserRankI
         <span className="nickname">{nickname}</span>
         {myNickname === nickname && <div className="me-mark">나</div>}
       </div>
-      <div className='win-lose-box'>
-        <WinLoseBox wins={wins} losses={losses} color={color} size='font-xs' />
+      <div className="win-lose-box">
+        <WinLoseBox wins={wins} losses={losses} color={color} size="font-xs" />
       </div>
     </div>
   );

--- a/frontend/src/constants/apiEndpoints.ts
+++ b/frontend/src/constants/apiEndpoints.ts
@@ -10,5 +10,5 @@ export const API_ENDPOINTS = {
   ACCEPT_FRIEND: (nickname: string) => `friend/accept/${nickname}`,
   REJECT_FRIEND: (nickname: string) => `friend/reject/${nickname}`,
   CANCEL_FRIEND_APPLY: (nickname: string) => `friend/apply/${nickname}`,
-  GET_RANK: '/rank',
+  GET_RANKS: '/rank',
 };

--- a/frontend/src/constants/errorMessages.ts
+++ b/frontend/src/constants/errorMessages.ts
@@ -9,7 +9,7 @@ export type ErrorMessageKeys =
   | 'ACCEPT_FRIEND'
   | 'REJECT_FRIEND'
   | 'CANCEL_APPLY_FRIEND'
-  | 'GET_RANK'
+  | 'GET_RANKS'
   | 'COMMON';
 
 type ErrorMessages = {
@@ -83,7 +83,10 @@ export const ERROR_MESSAGES: ErrorMessages = {
     FAILED_CANCEL_APPLY_FRIEND: COMMON_MESSAGES.RETRY,
     UNKNOWN_USER: '존재하지 않는 유저입니다.',
   },
-  GET_RANK: {},
+  GET_RANKS: {
+    FAILED_GET_RANKS: COMMON_MESSAGES.RETRY,
+    INVALID_USERID: COMMON_MESSAGES.RE_LOGIN,
+  },
   COMMON: {
     ERR_NETWORK: '서버 연결이 불안정합니다.\n잠시 후 다시 시도해주세요.',
     MISSING_JWT_ACCESS_TOKEN: COMMON_MESSAGES.RE_LOGIN,

--- a/frontend/src/hooks/friend/useSearchFriend.ts
+++ b/frontend/src/hooks/friend/useSearchFriend.ts
@@ -2,7 +2,7 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 import { applyFriend, cancelApplyFriend, searchFriend } from 'api/friendApi';
 import { queryClient } from 'api/queryClient';
 import { AxiosError } from 'axios';
-import { COMMON_MESSAGES, ERROR_MESSAGES } from 'constants/errorMessages';
+import { ERROR_MESSAGES } from 'constants/errorMessages';
 import { QUERY_KEYS } from 'constants/reactQueryKeys';
 import { useEffect, useState } from 'react';
 import { useErrorStore } from 'stores/errorStore';

--- a/frontend/src/hooks/rank/useRank.ts
+++ b/frontend/src/hooks/rank/useRank.ts
@@ -1,0 +1,37 @@
+import { useQuery } from '@tanstack/react-query';
+import { getRankList } from 'api/rankApi';
+import { AxiosError } from 'axios';
+import { QUERY_KEYS } from 'constants/reactQueryKeys';
+import { useEffect } from 'react';
+import { useErrorStore } from 'stores/errorStore';
+
+export const useRank = () => {
+  const { setErrorMessage } = useErrorStore();
+
+  const { data, isFetching, isError, error } = useQuery({
+    queryKey: [QUERY_KEYS.ranks],
+    queryFn: getRankList,
+    staleTime: 1000 * 60 * 30,
+  });
+
+  useEffect(() => {
+    if (!isError || !(error instanceof AxiosError)) {
+      return;
+    }
+    const errorType = error.response?.data.errorType;
+
+    // axiosInstance에서 처리한 에러를 중복 처리하지 않기 위해
+    if (
+      errorType === 'EXPIRED_JWT_TOKEN' ||
+      errorType === 'MISSING_JWT_ACCESS_TOKEN'
+    ) {
+      return;
+    }
+    setErrorMessage('GET_RANKS', errorType);
+  }, [isError, error]);
+
+  return {
+    data,
+    isFetching,
+  };
+};

--- a/frontend/src/pages/RankPage.tsx
+++ b/frontend/src/pages/RankPage.tsx
@@ -1,54 +1,47 @@
 import Title from 'components/rank/Title';
 import UserRankItem from 'components/rank/UserRankItem';
 import 'styles/pages/rank-page.scss';
+import { useRank } from 'hooks/rank/useRank';
+import { LocalLoadingSpinner } from 'components/common/LocalLoadingSpinner';
 
 const RankPage = () => {
-  const rankList = {
-    me: { nickname: '은지0', wins: 4, losses: 5, rank: 7 },
-    users: [
-      { nickname: '은지1', wins: 10, losses: 5, isMe: false, rank: 1 },
-      { nickname: '은지2', wins: 9, losses: 5, isMe: false, rank: 2 },
-      { nickname: '은지3', wins: 8, losses: 5, isMe: false, rank: 3 },
-      { nickname: '은지4', wins: 7, losses: 5, isMe: false, rank: 4 },
-      { nickname: '은지5', wins: 6, losses: 5, isMe: false, rank: 5 },
-      { nickname: '은지6', wins: 5, losses: 5, isMe: false, rank: 6 },
-      { nickname: '은지0', wins: 4, losses: 5, isMe: true, rank: 7 },
-      { nickname: '은지8', wins: 3, losses: 5, isMe: false, rank: 8 },
-      { nickname: '은지9', wins: 2, losses: 5, isMe: false, rank: 9 },
-      { nickname: '은지10', wins: 1, losses: 5, isMe: false, rank: 10 },
-    ],
-  };
+  const { data, isFetching } = useRank();
 
   return (
     <div className="rank-page">
       <Title />
       <section className="rank-section">
-        <section className='my-rank-section'>
-          <UserRankItem
-            userInfo={{
-              nickname: rankList.me.nickname,
-              wins: rankList.me.wins,
-              losses: rankList.me.losses,
-            }}
-            myNickname={rankList.me.nickname}
-            rank={rankList.me.rank}
-            isMyRankSection={true}
-          />
-        </section>
-        <section className='users-rank-section'>
-          {rankList.users.map((user) => (
-            <UserRankItem
-              userInfo={{
-                nickname: user.nickname,
-                wins: user.wins,
-                losses: user.losses,
-              }}
-              myNickname={rankList.me.nickname}
-              rank={user.rank}
-              isMyRankSection={false}
-            />
-          ))}
-        </section>
+        {isFetching && <LocalLoadingSpinner />}
+        {!isFetching && data && (
+          <>
+            <section className="my-rank-section">
+              <UserRankItem
+                userInfo={{
+                  nickname: data.me.nickname,
+                  wins: data.me.wins,
+                  losses: data.me.losses,
+                }}
+                myNickname={data.me.nickname}
+                rank={data.me.rank}
+                isMyRankSection={true}
+              />
+            </section>
+            <section className="top10-rank-section">
+              {data.top10.map((user) => (
+                <UserRankItem
+                  userInfo={{
+                    nickname: user.nickname,
+                    wins: user.wins,
+                    losses: user.losses,
+                  }}
+                  myNickname={data.me.nickname}
+                  rank={user.rank}
+                  isMyRankSection={false}
+                />
+              ))}
+            </section>
+          </>
+        )}
       </section>
     </div>
   );

--- a/frontend/src/styles/pages/rank-page.scss
+++ b/frontend/src/styles/pages/rank-page.scss
@@ -14,7 +14,7 @@
       height: 8%;
     }
 
-    .users-rank-section {
+    .top10-rank-section {
       display: flex;
       flex-direction: column;
       gap: 9px;

--- a/frontend/src/types/rank.ts
+++ b/frontend/src/types/rank.ts
@@ -1,0 +1,11 @@
+export interface rankInfoInterface {
+  nickname: string;
+  wins: number;
+  losses: number;
+  rank: number;
+}
+
+export interface GetRankListResponse {
+  me: rankInfoInterface;
+  top10: rankInfoInterface[];
+}


### PR DESCRIPTION
**순위 조회 api 연동**

- 로직 (→구현 예정)

      - A와 B가 게임이 끝나면

          - A와 B의 wins, losses 갱신

          - 전체 순위 다시 계산 후, A와 B의 rank 갱신 +  top10 갱신

          - A와 B의 브라우저에서 순위 (me, top10) 캐시 무효화 (UI 업데이트)

          - 이때, C의 브라우저에서는 순위 UI 변화가 있을까?

                    - 본인이 게임을 하면, 순위 캐시 무효화 (UI 업데이트)

                    - 본인이 게임을 안하면, 30분동안 순위 캐시 무효화(UI 업데이트)가 안됨 (staleTime을 30분으로 설정해뒀기 때문)

- 결론 (→완료)

    - top10에만 새로고침 버튼을 만들지 않고

    - 내 순위, top10 순위를 같은 api로 호출하고

    - staleTime을 30분으로 설정해서 최소 30분 동안은 캐시에 있는 데이터 쓰자! 